### PR TITLE
Fix fizzbuzz program in P01-C01-introduction.ipynb

### DIFF
--- a/P01-C01-introduction.ipynb
+++ b/P01-C01-introduction.ipynb
@@ -146,13 +146,15 @@
    "source": [
     "res = []\n",
     "for i in range(1,101):\n",
-    "    if i % 3 == 0:\n",
+    "    if i % 3 == 0 and i % 5 == 0:\n",
+    "        res.append('fizzbuzz')\n",
+    "    elif i % 3 == 0:\n",
     "        res.append('fizz')\n",
     "    elif i % 5 == 0:\n",
     "        res.append('buzz')\n",
     "    else:\n",
     "        res.append(str(i))\n",
-    "' '.join(res)"
+    "print(' '.join(res))"
    ]
   },
   {

--- a/P01-C01-introduction.ipynb
+++ b/P01-C01-introduction.ipynb
@@ -146,7 +146,7 @@
    "source": [
     "res = []\n",
     "for i in range(1,101):\n",
-    "    if i % 3 == 0 and i % 5 == 0:\n",
+    "    if i % 15 == 0:\n",
     "        res.append('fizzbuzz')\n",
     "    elif i % 3 == 0:\n",
     "        res.append('fizz')\n",


### PR DESCRIPTION
Fix the fizzbuzz program to match the specifications of printing both fizz and buzz when the number is divisible by both 3 and 5.
Also, it is advisable to print the result using print() rather than relying on Jupyter notebook's implicit print functionality so that the program can be downloaded and run by the reader and have the exact same behavior as in the Jupyter notebook.