### PR TITLE
fix a grammer error

### DIFF
--- a/chapter07_distributed-learning/multiple-gpus-scratch.ipynb
+++ b/chapter07_distributed-learning/multiple-gpus-scratch.ipynb
@@ -107,7 +107,7 @@
     "We first demonstrate how to run workloads in parallel. \n",
     "Writing parallel code in Python in non-trivial, but fortunately, \n",
     "MXNet is able to automatically parallelize the workloads. \n",
-    "Two technologies technologies help to achieve this goal.\n",
+    "Two technologies help to achieve this goal.\n",
     "\n",
     "First, workloads, such as `nd.dot` are pushed into the backend engine for *lazy evaluation*. \n",
     "That is, Python merely pushes the workload `nd.dot` and returns immediately \n",


### PR DESCRIPTION
In the first paragraph of section Automatic Parallelization, there are two "technologies ".