### PR TITLE
Typo fix. informatino to information.

### DIFF
--- a/chapter09_natural-language-processing/tree-lstm.ipynb
+++ b/chapter09_natural-language-processing/tree-lstm.ipynb
@@ -26,7 +26,7 @@
     "But while those models are impressive, they still may be leaving some knowledge on the table.\n",
     "To begin with, we know a priori that sentence have a grammatical structure. \n",
     "And we already have some tools that are very good at recovering parse trees that reflect grammatical structure of the sentences.\n",
-    "While it may be possible for an LSTM to learn this informatino implicitly,\n",
+    "While it may be possible for an LSTM to learn this information implicitly,\n",
     "it's often a good idea to build known information into the structure of a neural network.\n",
     "Take for example convolutional neural networks.\n",
     "They build in the prior knowledge that low level feature should be translation-invariant.\n",


### PR DESCRIPTION
Fix a minor typo in Chapter 9 Natural Language Processing. Change informatino to information.
@zackchase 