### PR TITLE
minor grammar and numbering edit in introduction

### DIFF
--- a/chapter01_crashcourse/introduction.ipynb
+++ b/chapter01_crashcourse/introduction.ipynb
@@ -182,11 +182,11 @@
     "and it's called *supervised learning*. \n",
     "Even within deep learning, there are many other approaches, \n",
     "and we'll discuss each in subsequent sections. \n",
-    "To get going with at machine learning, we need four things: \n",
+    "To get going with machine learning, we need four things: \n",
     "1. Data\n",
-    "1. A model of how to transform the data\n",
-    "1. A loss function to measure how well we're doing\n",
-    "1. An algorithm to tweak the model parameters such that the loss function is minimized\n",
+    "2. A model of how to transform the data\n",
+    "3. A loss function to measure how well we're doing\n",
+    "4. An algorithm to tweak the model parameters such that the loss function is minimized\n",
     "\n",
     "### Data \n",
     "\n",
@@ -867,7 +867,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The first paragraph of the "Basics of machine learning" section
has an "at" that needs to be removed from the last line. In the gluon site,
the numbering does not render properly even though it does in the Jupyter notebook
UI. I changed 1. 1. 1. 1. to 1. 2. 3. 4.