### PR TITLE
remove test utils call

### DIFF
--- a/chapter03_deep-neural-networks/mlp-gluon.ipynb
+++ b/chapter03_deep-neural-networks/mlp-gluon.ipynb
@@ -57,7 +57,6 @@
    },
    "outputs": [],
    "source": [
-    "mnist = mx.test_utils.get_mnist()\n",
     "batch_size = 64\n",
     "num_inputs = 784\n",
     "num_outputs = 10\n",


### PR DESCRIPTION
the gluon helper function for mnist will download the dataset, so you don't need to use the utils function anymore...