### PR TITLE
For lenet cnn use max-pooling. learning-rate independent of gpus.

### DIFF
--- a/chapter07_distributed-learning/multiple-gpus-gluon.ipynb
+++ b/chapter07_distributed-learning/multiple-gpus-gluon.ipynb
@@ -321,7 +321,7 @@
     "        print('         validation accuracy = %.4f'%(correct/num))\n",
     "        \n",
     "run(1, 64, .3)        \n",
-    "run(GPU_COUNT, 64*GPU_COUNT, .3*GPU_COUNT)            "
+    "run(GPU_COUNT, 64*GPU_COUNT, .3)            "
    ]
   },
   {
@@ -366,7 +366,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/chapter07_distributed-learning/multiple-gpus-scratch.ipynb
+++ b/chapter07_distributed-learning/multiple-gpus-scratch.ipynb
@@ -28,32 +28,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sun Jul 23 09:01:41 2017       \n",
-      "+-----------------------------------------------------------------------------+\n",
-      "| NVIDIA-SMI 375.66                 Driver Version: 375.66                    |\n",
-      "|-------------------------------+----------------------+----------------------+\n",
-      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\n",
-      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\n",
-      "|===============================+======================+======================|\n",
-      "|   0  GRID K520           Off  | 0000:00:03.0     Off |                  N/A |\n",
-      "| N/A   42C    P0    42W / 125W |      0MiB /  4036MiB |      0%      Default |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "|   1  GRID K520           Off  | 0000:00:04.0     Off |                  N/A |\n",
-      "| N/A   34C    P0    41W / 125W |      0MiB /  4036MiB |      0%      Default |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "|   2  GRID K520           Off  | 0000:00:05.0     Off |                  N/A |\n",
-      "| N/A   32C    P0    42W / 125W |      0MiB /  4036MiB |      0%      Default |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "|   3  GRID K520           Off  | 0000:00:06.0     Off |                  N/A |\n",
-      "| N/A   28C    P0    37W / 125W |      0MiB /  4036MiB |      0%      Default |\n",
-      "+-------------------------------+----------------------+----------------------+\n",
-      "                                                                               \n",
-      "+-----------------------------------------------------------------------------+\n",
-      "| Processes:                                                       GPU Memory |\n",
-      "|  GPU       PID  Type  Process name                               Usage      |\n",
-      "|=============================================================================|\n",
-      "|  No running processes found                                                 |\n",
-      "+-----------------------------------------------------------------------------+\n"
+      "Fri Oct 13 00:11:36 2017       \r\n",
+      "+-----------------------------------------------------------------------------+\r\n",
+      "| NVIDIA-SMI 375.66                 Driver Version: 375.66                    |\r\n",
+      "|-------------------------------+----------------------+----------------------+\r\n",
+      "| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |\r\n",
+      "| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |\r\n",
+      "|===============================+======================+======================|\r\n",
+      "|   0  Tesla M60           On   | 0000:00:1B.0     Off |                    0 |\r\n",
+      "| N/A   34C    P8    13W / 150W |      0MiB /  7613MiB |      0%      Default |\r\n",
+      "+-------------------------------+----------------------+----------------------+\r\n",
+      "|   1  Tesla M60           On   | 0000:00:1C.0     Off |                    0 |\r\n",
+      "| N/A   29C    P8    15W / 150W |      0MiB /  7613MiB |      0%      Default |\r\n",
+      "+-------------------------------+----------------------+----------------------+\r\n",
+      "|   2  Tesla M60           On   | 0000:00:1D.0     Off |                    0 |\r\n",
+      "| N/A   33C    P8    13W / 150W |      0MiB /  7613MiB |      0%      Default |\r\n",
+      "+-------------------------------+----------------------+----------------------+\r\n",
+      "|   3  Tesla M60           On   | 0000:00:1E.0     Off |                    0 |\r\n",
+      "| N/A   31C    P8    14W / 150W |      0MiB /  7613MiB |      0%      Default |\r\n",
+      "+-------------------------------+----------------------+----------------------+\r\n",
+      "                                                                               \r\n",
+      "+-----------------------------------------------------------------------------+\r\n",
+      "| Processes:                                                       GPU Memory |\r\n",
+      "|  GPU       PID  Type  Process name                               Usage      |\r\n",
+      "|=============================================================================|\r\n",
+      "|  No running processes found                                                 |\r\n",
+      "+-----------------------------------------------------------------------------+\r\n"
      ]
     }
    ],
@@ -127,9 +127,9 @@
      "output_type": "stream",
      "text": [
       "=== workloads are pushed into the backend engine ===\n",
-      "0.000778 sec\n",
+      "0.001160 sec\n",
       "=== workloads are finished ===\n",
-      "0.254895 sec\n"
+      "0.174040 sec\n"
      ]
     }
    ],
@@ -180,9 +180,9 @@
      "output_type": "stream",
      "text": [
       "=== Run on GPU 0 and 1 in sequential ===\n",
-      "time: 2.305928 sec\n",
+      "time: 1.842752 sec\n",
       "=== Run on GPU 0 and 1 in parallel ===\n",
-      "time: 1.080638 sec\n"
+      "time: 0.396227 sec\n"
      ]
     }
    ],
@@ -226,9 +226,9 @@
      "output_type": "stream",
      "text": [
       "=== Run on GPU 0 and then copy results to CPU in sequential ===\n",
-      "1.36029291153\n",
+      "0.6489872932434082\n",
       "=== Run and copy in parallel ===\n",
-      "1.10839509964\n"
+      "0.39962267875671387\n"
      ]
     }
    ],
@@ -290,11 +290,11 @@
     "    # first conv\n",
     "    h1_conv = nd.Convolution(data=X, weight=params[0], bias=params[1], kernel=(3,3), num_filter=20)\n",
     "    h1_activation = nd.relu(h1_conv)\n",
-    "    h1 = nd.Pooling(data=h1_activation, pool_type=\"avg\", kernel=(2,2), stride=(2,2))\n",
+    "    h1 = nd.Pooling(data=h1_activation, pool_type=\"max\", kernel=(2,2), stride=(2,2))\n",
     "    # second conv\n",
     "    h2_conv = nd.Convolution(data=h1, weight=params[2], bias=params[3], kernel=(5,5), num_filter=50)\n",
     "    h2_activation = nd.relu(h2_conv)\n",
-    "    h2 = nd.Pooling(data=h2_activation, pool_type=\"avg\", kernel=(2,2), stride=(2,2))\n",
+    "    h2 = nd.Pooling(data=h2_activation, pool_type=\"max\", kernel=(2,2), stride=(2,2))\n",
     "    h2 = nd.flatten(h2)\n",
     "    # first fullc\n",
     "    h3_linear = nd.dot(h2, params[4]) + params[5]\n",
@@ -590,16 +590,16 @@
      "text": [
       "Running on [gpu(0)]\n",
       "Batch size is 64\n",
-      "Epoch 0, training time = 5.3 sec\n",
-      "         validation accuracy = 0.9551\n",
-      "Epoch 1, training time = 4.9 sec\n",
-      "         validation accuracy = 0.9769\n",
-      "Epoch 2, training time = 4.9 sec\n",
-      "         validation accuracy = 0.9823\n",
-      "Epoch 3, training time = 4.9 sec\n",
-      "         validation accuracy = 0.9845\n",
-      "Epoch 4, training time = 5.0 sec\n",
-      "         validation accuracy = 0.9810\n"
+      "Epoch 0, training time = 3.7 sec\n",
+      "         validation accuracy = 0.9586\n",
+      "Epoch 1, training time = 3.8 sec\n",
+      "         validation accuracy = 0.9748\n",
+      "Epoch 2, training time = 3.6 sec\n",
+      "         validation accuracy = 0.9795\n",
+      "Epoch 3, training time = 3.5 sec\n",
+      "         validation accuracy = 0.9854\n",
+      "Epoch 4, training time = 3.5 sec\n",
+      "         validation accuracy = 0.9859\n"
      ]
     }
    ],
@@ -611,7 +611,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Running on multiple GPUs, we often want to increase the batch size so that each GPU still gets a large enough batch size for good computation performance. A larger batch size sometimes slows down the convergence, we often want to increases the learning rate as well.  "
+    "Running on multiple GPUs, we often want to increase the batch size so that each GPU still gets a large enough batch size for good computation performance. (A larger batch size sometimes slows down the convergence, we often want to increases the learning rate as well but in this case we'll keep it same. Feel free to try higher learning rates.)"
    ]
   },
   {
@@ -625,21 +625,21 @@
      "text": [
       "Running on [gpu(0), gpu(1)]\n",
       "Batch size is 128\n",
-      "Epoch 0, training time = 3.2 sec\n",
-      "         validation accuracy = 0.9255\n",
-      "Epoch 1, training time = 3.0 sec\n",
-      "         validation accuracy = 0.9656\n",
-      "Epoch 2, training time = 3.2 sec\n",
-      "         validation accuracy = 0.9762\n",
-      "Epoch 3, training time = 3.2 sec\n",
-      "         validation accuracy = 0.9790\n",
-      "Epoch 4, training time = 3.1 sec\n",
-      "         validation accuracy = 0.9831\n"
+      "Epoch 0, training time = 3.9 sec\n",
+      "         validation accuracy = 0.8873\n",
+      "Epoch 1, training time = 3.4 sec\n",
+      "         validation accuracy = 0.9477\n",
+      "Epoch 2, training time = 3.3 sec\n",
+      "         validation accuracy = 0.9614\n",
+      "Epoch 3, training time = 3.1 sec\n",
+      "         validation accuracy = 0.9798\n",
+      "Epoch 4, training time = 2.8 sec\n",
+      "         validation accuracy = 0.9824\n"
      ]
     }
    ],
    "source": [
-    "run(2, 128, 0.6)"
+    "run(2, 128, 0.3)"
    ]
   },
   {
@@ -685,7 +685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Currently there is a mismatch in the n/w used for "Training on multiple GPUs from scratch" and for "Training on multiple GPUs with gluon". We should try to use the same pooling everywhere. Since lenet uses max-pooling using that as the standard here.

Second issue is that learning rate is made a multiple of gpus. Under certain cases that makes sense but under this case, it reduces the accuracy significantly which I don't think is a good idea for tutorials for beginners as it throws them off. For instance w/ max-pooling, gluon tutorial resulted in an accuray of around 11% on gpus (learning rate = 0.6) whereas on 1 gpu it was about 98% (learning = 0.3)