### PR TITLE
fix errors in perception and softmax

### DIFF
--- a/chapter02_supervised-learning/perceptron.ipynb
+++ b/chapter02_supervised-learning/perceptron.ipynb
@@ -66,7 +66,7 @@
     "        margin = nd.dot(tmp, wfake) + bfake\n",
     "        if (nd.norm(tmp).asscalar() < 3) & (abs(margin.asscalar()) > epsilon):\n",
     "            X[i,:] = tmp\n",
-    "            Y[i] = 1 if margin > 0 else -1\n",
+    "            Y[i] = 1 if margin.asscalar() > 0 else -1\n",
     "            i += 1\n",
     "    return X, Y\n",
     "\n",
@@ -86,7 +86,7 @@
     "    zz = nd.zeros(shape=(xgrid.size, ygrid.size, 2))\n",
     "    zz[:,:,0] = nd.array(xx)\n",
     "    zz[:,:,1] = nd.array(yy)\n",
-    "    vv = nd.dot(zz,w) + b\n",
+    "    vv = nd.dot(zz,w) + d\n",
     "    CS = plt.contour(xgrid,ygrid,vv.asnumpy())\n",
     "    plt.clabel(CS, inline=1, fontsize=10)\n",
     "            \n",
@@ -399,21 +399,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/chapter02_supervised-learning/softmax-regression-scratch.ipynb
+++ b/chapter02_supervised-learning/softmax-regression-scratch.ipynb
@@ -82,7 +82,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "image, label = mnist_train[0]\n",
@@ -127,7 +129,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "im = mx.nd.tile(image, (1,1,3))\n",
@@ -144,7 +148,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -219,8 +225,8 @@
    },
    "outputs": [],
    "source": [
-    "W = nd.random_normal(shape=(num_inputs, num_outputs))\n",
-    "b = nd.random_normal(shape=num_outputs)\n",
+    "W = nd.random_normal(shape=(num_inputs, num_outputs),ctx=ctx)\n",
+    "b = nd.random_normal(shape=num_outputs,ctx=ctx)\n",
     "\n",
     "params = [W, b]"
    ]
@@ -273,7 +279,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "sample_y_linear = nd.random_normal(shape=(2,10))\n",
@@ -291,7 +299,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(nd.sum(sample_yhat, axis=1))"
@@ -418,7 +428,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "evaluate_accuracy(test_data, net)"
@@ -434,7 +446,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "epochs = 10\n",
@@ -477,7 +491,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Define the function to do prediction\n",
@@ -539,21 +555,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1.  The truth value of an NDArray is ambiguous. Please convert to number with asscalar() first
location: Perceptron chapter
  i = 0
    while (i < samples):
        tmp = nd.random_normal(shape=(1, dimension))
        margin = nd.dot(tmp, wfake) + bfake
        if (nd.norm(tmp).asscalar() < 3) & (abs(margin.asscalar()) > epsilon):
            X[i, :] = tmp
            Y[i] = 1 **if margin > 0 else -1**
            i += 1
    return X, Y

**change margin to margin.asscalar()**

2.  Check failed: ndinputs[i].ctx().dev_mask() == ctx.dev_mask() (1 vs. 2) All inputs must live on the same context
location: softmax chapter
if we change ctx=mx.cpu() to ctx=mx.gpu(id). we will encounter this error. That is because not all inputs are on gpu. 
To fix it, we should allocate W and b on gpu too:

W = nd.random_normal(shape=(num_inputs, num_outputs),**ctx=ctx**)
b = nd.random_normal(shape=num_outputs,**ctx=ctx**)

