### PR TITLE
added explanation of the sense of dropout parameter

### DIFF
--- a/chapter03_deep-neural-networks/mlp-dropout-gluon.ipynb
+++ b/chapter03_deep-neural-networks/mlp-dropout-gluon.ipynb
@@ -71,7 +71,8 @@
    "source": [
     "## Define the model\n",
     "\n",
-    "Now we can add Dropout following each of our hidden layers. "
+    "Now we can add Dropout following each of our hidden layers. \n",
+    "A dropout of .6 would mean that 60% are dropped out and 40% are kept.\n"
    ]
   },
   {

--- a/chapter03_deep-neural-networks/mlp-dropout-gluon.ipynb
+++ b/chapter03_deep-neural-networks/mlp-dropout-gluon.ipynb
@@ -72,7 +72,7 @@
     "## Define the model\n",
     "\n",
     "Now we can add Dropout following each of our hidden layers. \n",
-    "A dropout of .6 would mean that 60% are dropped out and 40% are kept.\n"
+    "Setting the dropout probability to .6 would mean that 60% of activations are dropped (set to zero) out and 40% are kept.\n"
    ]
   },
   {


### PR DESCRIPTION
Some coders may be more familiar with pkeep, so it is best to add explanation of which way the % works. An alternative would be to change the code and have the % different for each layer and explain it in the code.