### PR TITLE
Explaining log_softmax

### DIFF
--- a/chapter03_deep-neural-networks/mlp-scratch.ipynb
+++ b/chapter03_deep-neural-networks/mlp-scratch.ipynb
@@ -282,12 +282,16 @@
    "source": [
     "Mathematically, that's a perfectly reasonable thing to do. However, computationally, things can get hairy. We'll revisit the issue at length in a chapter more dedicated to implementation and less interested in statistical modeling. But we're going to make a change here so we want to give you the gist of why.\n",
     "\n",
-    "When we calculate the softmax partition function, we take a sum of exponential functions:\n",
-    "$\\sum_{i=1}^{n} e^{z_i}$. When we also calculate our numerators as exponential functions, then this can give rise to some big numbers in our intermediate calculations. The pairing of big numbers and low precision mathematics tends to make things go crazy. As a result, if we use our naive softmax implementation, we might get horrific not a number (``nan``) results printed to screen.\n",
+    "Recall that the softmax function calculates $\\hat y_j = \\frac{e^{z_j}}{\\sum_{i=1}^{n} e^{z_i}}$, where $\\hat y_j$ is the j-th element of the input ``yhat`` variable in function ``cross_entropy`` and $z_j$ is the j-th element of the input ``y_linear`` variable in function ``softmax``\n",
     "\n",
-    "Our salvation is that even though we're computing these exponential functions, we ultimately plan to take their log in the cross-entropy functions. It turns out that by combining these two operators ``softmax`` and ``cross_entropy`` together, we can elude the numerical stability issues that might otherwise plague us during backpropagation. We'll want to keep the conventional softmax function handy in case we ever want to evaluate the probabilities output by our model.\n",
+    "If some of the $z_i$ are very large (i.e. very positive), $e^{z_i}$ might be larger than the largest number we can have for certain types of ``float`` (i.e. overflow). This would make the denominator (and/or numerator) ``inf`` and we get zero, or ``inf``, or ``nan`` for $\\hat y_j$. In any case, we won't get a well-defined return value for ``cross_entropy``. This is the reason we subtract $\\text{max}(z_i)$ from all $z_i$ first in ``softmax`` function. You can verify that this shifting in $z_i$ will not change the return value of ``softmax``.\n",
     "\n",
-    "But instead of passing softmax probabilities into our loss function - we'll just pass our ``yhat_linear`` and compute the softmax and its log all at once inside the softmax_cross_entropy loss function simultaneously, which does smart things like the log-sum-exp trick ([see on Wikipedia](https://en.wikipedia.org/wiki/LogSumExp)).\n"
+    "After the above subtraction/ normalization step, it is possible that $z_j$ is very negative. Thus, $e^{z_j}$ will be very close to zero and might be rounded to zero due to finite precision (i.e underflow), which makes $\\hat y_j$ zero and we get ``-inf`` for $\\text{log}(\\hat y_j)$. A few steps down the road in backpropagation, we starts to get horrific not-a-number (``nan``) results printed to screen.\n",
+    "\n",
+    "Our salvation is that even though we're computing these exponential functions, we ultimately plan to take their log in the cross-entropy functions. It turns out that by combining these two operators ``softmax`` and ``cross_entropy`` together, we can elude the numerical stability issues that might otherwise plague us during backpropagation. As shown in the equation below, we avoided calculating $e^{z_j}$ but directly used $z_j$ due to $log(exp(\\cdot))$.\n",
+    "$$\\text{log}{(\\hat y_j)} = \\text{log}\\left( \\frac{e^{z_j}}{\\sum_{i=1}^{n} e^{z_i}}\\right) = \\text{log}{(e^{z_j})}-\\text{log}{\\left( \\sum_{i=1}^{n} e^{z_i} \\right)} = z_j -\\text{log}{\\left( \\sum_{i=1}^{n} e^{z_i} \\right)}$$\n",
+    "\n",
+    "We'll want to keep the conventional softmax function handy in case we ever want to evaluate the probabilities output by our model. But instead of passing softmax probabilities into our new loss function - we'll just pass our ``yhat_linear`` and compute the softmax and its log all at once inside the softmax_cross_entropy loss function simultaneously, which does smart things like the log-sum-exp trick ([see on Wikipedia](https://en.wikipedia.org/wiki/LogSumExp)).\n"
    ]
   },
   {
@@ -485,7 +489,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.2"
+  },
+  "widgets": {
+   "state": {},
+   "version": "1.1.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The existing qualitative description is already pretty long, I think we should just make it clear how log_softmax works.

Actually the description is slightly inaccurate. The worry about large numbers is the reason we do the subtraction of max in softmax (this hasn't been explained in other tutorials I think). The log softmax is mainly to deal with underflow (i.e. avoid exact zero softmax probably output).