### PR TITLE
Changed the Broken link from docs/C01-install.html to mxnet.io's installation guide

### DIFF
--- a/build/index.rst
+++ b/build/index.rst
@@ -18,7 +18,7 @@ To run these notebooks, a recent version of MXNet is required. The easiest way i
 
     $ pip install mxnet --pre --user
     
-More detailed instructions are available `here <docs/C01-install.html>`_
+More detailed instructions are available `here <https://mxnet.incubator.apache.org/install/index.html>`_
 
 
 Part 1: Deep Learning Fundamentals


### PR DESCRIPTION
#69 

More detailed instructions Link is broken in the [Dependencies Section](http://gluon.mxnet.io/#dependencies)

Broken Link : `http://gluon.mxnet.io/docs/C01-install.html`

Pointing the link to [Mxnet's Installation Guide](http://mxnet.incubator.apache.org/install/index.html)