### PR TITLE
Update linear-algebra.ipynb

### DIFF
--- a/chapter01_crashcourse/linear-algebra.ipynb
+++ b/chapter01_crashcourse/linear-algebra.ipynb
@@ -1122,7 +1122,7 @@
     "\n",
     "If you're eager to learn more about linear algebra, here are some of our favorite resources on the topic\n",
     "* For a solid primer on basics, check out Gilbert Strang's book [Introduction to Linear Algebra](http://math.mit.edu/~gs/linearalgebra/)\n",
-    "* Zico Kolter's [Linear Algebra Reivew and Reference](http://cs229.stanford.edu/section/cs229-linalg.pdf)"
+    "* Zico Kolter's [Linear Algebra Reivew and Reference](http://www.cs.cmu.edu/~zkolter/course/15-884/linalg-review.pdf)"
    ]
   },
   {


### PR DESCRIPTION
Updating the URL since Zico Kotler's "Linear Algebra Reivew and Reference" reference link was broken