### PR TITLE
fixed some typos; added context fix for multi-gpu

### DIFF
--- a/chapter08_computer-vision/fine-tuning.ipynb
+++ b/chapter08_computer-vision/fine-tuning.ipynb
@@ -27,7 +27,7 @@
     "most people aren't interested in ImageNet itself.\n",
     "They're interested in their own problems.\n",
     "Recognize people based on pictures of their faces.\n",
-    "Distinguish between photographs of $10$ different types of corral on the ocean floor. \n",
+    "Distinguish between photographs of $10$ different types of coral on the ocean floor. \n",
     "Usually when individuals (and not Amazon, Google, or inter-institutional *big science* initiatives)\n",
     "are interested in solving a computer vision problem,\n",
     "they come to the table with modestly sized datasets. \n",
@@ -98,7 +98,7 @@
     "Hybrid mode, uses the just in time compiler described in [our chapter on high performance training](../chapter07_distributed-learning/hybridize.ipynb)\n",
     "to make the network much faster to train. \n",
     "Since we're not working with any crazy dynamic graphs that can't be compiled, \n",
-    "there's not reason not to hybridize. \n",
+    "there's no reason not to hybridize. \n",
     "The batch size, number of training epochs, weight decay, and learing rate should all be familiar by now.\n",
     "The positive class weight, says how much more we should upweight the importance of positive instances (photos of hot dogs) in the objective function. \n",
     "We use this to combat the extreme class imbalance (not surprisingly, most pictures do not depict hot dogs). "
@@ -573,13 +573,22 @@
    "outputs": [],
    "source": [
     "# Uncomment below line and replace the file name with the last checkpoint.\n",
-    "# deep_dog_net.load_params('deep-dog-4.params', mx.cpu())\n",
+    "#deep_dog_net.load_params('deep-dog-4.params', contexts)\n",
     "#\n",
     "# Alternatively, you can uncomment the following lines to get the model that we finetuned,\n",
     "# with validation F1 score of 0.74.\n",
-    "download('https://apache-mxnet.s3-accelerate.amazonaws.com/gluon/models/deep-dog-5a342a6f.params',\n",
-    "         overwrite=True)\n",
-    "deep_dog_net.load_params('deep-dog-5a342a6f.params', mx.cpu())"
+    "#download('https://apache-mxnet.s3-accelerate.amazonaws.com/gluon/models/deep-dog-5a342a6f.params',\n",
+    "#         overwrite=True)\n",
+    "deep_dog_net.load_params('deep-dog-5a342a6f.params', contexts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deep_dog_net.export('nothotdog')"
    ]
   },
   {

--- a/chapter08_computer-vision/fine-tuning.ipynb
+++ b/chapter08_computer-vision/fine-tuning.ipynb
@@ -149,7 +149,10 @@
     "\n",
     "import mxnet as mx\n",
     "from mxnet.test_utils import download\n",
-    "mx.random.seed(127)"
+    "mx.random.seed(127)\n",
+    "\n",
+    "# setup the contexts; change the # of gpus in the settings section above\n",
+    "contexts = [mx.gpu(i) for i in range(gpus)] if gpus > 0 else [mx.cpu()]"
    ]
   },
   {
@@ -302,7 +305,7 @@
    "source": [
     "### DeepDog net\n",
     "\n",
-    "We can now use the feature extractor part from the pretrained squeezenet to build our own network. The model zoo, even handles the decaptiation for us. All we have to do is specify the number out of output classes in our new task, which we do via the keyword argument ``classes=2`."
+    "We can now use the feature extractor part from the pretrained squeezenet to build our own network. The model zoo, even handles the decaptiation for us. All we have to do is specify the number out of output classes in our new task, which we do via the keyword argument `classes=2`."
    ]
   },
   {
@@ -332,7 +335,7 @@
    "source": [
     "from skimage.color import rgba2rgb\n",
     "\n",
-    "def classify_hotdog(net, url):\n",
+    "def classify_hotdog(net, url, contexts):\n",
     "    I = io.imread(url)\n",
     "    if I.shape[2] == 4:\n",
     "        I = rgba2rgb(I)\n",
@@ -348,7 +351,7 @@
     "                                     std=mx.nd.array([0.229, 0.224, 0.225]))\n",
     "    image = mx.nd.transpose(image.astype('float32'), (2,1,0))\n",
     "    image = mx.nd.expand_dims(image, axis=0)\n",
-    "    out = mx.nd.SoftmaxActivation(net(image))\n",
+    "    out = mx.nd.SoftmaxActivation(net(image.as_in_context(contexts[0])))\n",
     "    print('Probabilities are: '+str(out[0].asnumpy()))\n",
     "    result = np.argmax(out.asnumpy())\n",
     "    outstring = ['Not hotdog!', 'Hotdog!']\n",
@@ -361,7 +364,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "classify_hotdog(deep_dog_net, '../img/real_hotdog.jpg')"
+    "classify_hotdog(deep_dog_net, '../img/real_hotdog.jpg', contexts)"
    ]
   },
   {
@@ -553,7 +556,6 @@
     "if mode == 'hybrid':\n",
     "    deep_dog_net.hybridize()\n",
     "if epochs > 0:\n",
-    "    contexts = [mx.gpu(i) for i in range(gpus)] if gpus > 0 else [mx.cpu()]\n",
     "    deep_dog_net.collect_params().reset_ctx(contexts)\n",
     "    train(deep_dog_net, train_iter, val_iter, epochs, contexts)"
    ]
@@ -573,7 +575,7 @@
    "outputs": [],
    "source": [
     "# Uncomment below line and replace the file name with the last checkpoint.\n",
-    "# deep_dog_net.load_params('deep-dog-4.params', contexts)\n",
+    "# deep_dog_net.load_params('deep-dog-3.params', contexts)\n",
     "#\n",
     "# Alternatively, you can uncomment the following lines to get the model that we finetuned,\n",
     "# with validation F1 score of 0.74.\n",
@@ -588,7 +590,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "classify_hotdog(deep_dog_net, '../img/real_hotdog.jpg')"
+    "classify_hotdog(deep_dog_net, '../img/real_hotdog.jpg', contexts)"
    ]
   },
   {
@@ -597,7 +599,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "classify_hotdog(deep_dog_net, '../img/leg_hotdog.jpg')"
+    "classify_hotdog(deep_dog_net, '../img/leg_hotdog.jpg', contexts)"
    ]
   },
   {
@@ -608,7 +610,7 @@
    },
    "outputs": [],
    "source": [
-    "classify_hotdog(deep_dog_net, '../img/dog_hotdog.jpg')"
+    "classify_hotdog(deep_dog_net, '../img/dog_hotdog.jpg', contexts)"
    ]
   },
   {

--- a/chapter08_computer-vision/fine-tuning.ipynb
+++ b/chapter08_computer-vision/fine-tuning.ipynb
@@ -573,22 +573,13 @@
    "outputs": [],
    "source": [
     "# Uncomment below line and replace the file name with the last checkpoint.\n",
-    "#deep_dog_net.load_params('deep-dog-4.params', contexts)\n",
+    "# deep_dog_net.load_params('deep-dog-4.params', contexts)\n",
     "#\n",
     "# Alternatively, you can uncomment the following lines to get the model that we finetuned,\n",
     "# with validation F1 score of 0.74.\n",
-    "#download('https://apache-mxnet.s3-accelerate.amazonaws.com/gluon/models/deep-dog-5a342a6f.params',\n",
-    "#         overwrite=True)\n",
+    "download('https://apache-mxnet.s3-accelerate.amazonaws.com/gluon/models/deep-dog-5a342a6f.params',\n",
+    "         overwrite=True)\n",
     "deep_dog_net.load_params('deep-dog-5a342a6f.params', contexts)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "deep_dog_net.export('nothotdog')"
    ]
   },
   {


### PR DESCRIPTION
I tried running this on a P3 with 4 GPUs and hit errors there at the end. Was able to bypass the first wave by adding context, and verified this still works with CPU only. 

Would be happy to add additional fixes, but I'm not sure how to fix it, so maybe just go with this first pass and circle back.

This was the issue I partially resolved but just pushed it down a bit...
It would fail here:
```
deep_dog_net.load_params('deep-dog-5a342a6f.params', mx.cpu())
```
But changing `mx.cpu()` to `contexts` gets it past that block.
Then it fails on:
```
classify_hotdog(deep_dog_net, '../img/real_hotdog.jpg')
...
RuntimeError: Parameter deep_dog_conv0_weight was not initialized on context cpu(0). It was only initialized on [gpu(0), gpu(1), gpu(2), gpu(3)].
```
classify_hotdog doesn't take a context param, so...

Anyway, here's a partial fix.