### PR TITLE
gan-intro: minor fixes

### DIFF
--- a/chapter14_generative-adversarial-networks/gan-intro.ipynb
+++ b/chapter14_generative-adversarial-networks/gan-intro.ipynb
@@ -114,8 +114,8 @@
     "X = nd.random_normal(shape=(1000, 2))\n",
     "A = nd.array([[1, 2], [-0.1, 0.5]])\n",
     "b = nd.array([1, 2])\n",
-    "X = nd.dot(X,A) + b\n",
-    "Y = nd.ones(shape=(1000,1))\n",
+    "X = nd.dot(X, A) + b\n",
+    "Y = nd.ones(shape=(1000, 1))\n",
     "\n",
     "# and stick them into an iterator\n",
     "batch_size = 4\n",
@@ -157,7 +157,7 @@
     }
    ],
    "source": [
-    "plt.scatter(X[:, 0].asnumpy(),X[:,1].asnumpy())\n",
+    "plt.scatter(X[:,0].asnumpy(), X[:,1].asnumpy())\n",
     "plt.show()\n",
     "print(\"The covariance matrix is\")\n",
     "print(nd.dot(A.T, A))"
@@ -191,7 +191,7 @@
     "netD = nn.Sequential()\n",
     "with netD.name_scope():\n",
     "    netD.add(nn.Dense(5, activation='tanh'))\n",
-    "    netD.add(nn.Dense(3 ,activation='tanh'))\n",
+    "    netD.add(nn.Dense(3, activation='tanh'))\n",
     "    netD.add(nn.Dense(2))\n",
     "\n",
     "# loss\n",
@@ -482,8 +482,8 @@
     "    print('time: %f' % (time.time() - tic))\n",
     "    noise = nd.random_normal(shape=(100, 2), ctx=ctx)\n",
     "    fake = netG(noise)\n",
-    "    plt.scatter(X[:, 0].asnumpy(),X[:,1].asnumpy())\n",
-    "    plt.scatter(fake[:,0].asnumpy(),fake[:,1].asnumpy())\n",
+    "    plt.scatter(X[:,0].asnumpy(), X[:,1].asnumpy())\n",
+    "    plt.scatter(fake[:,0].asnumpy(), fake[:,1].asnumpy())\n",
     "    plt.show()"
    ]
   },
@@ -516,8 +516,8 @@
     "noise = mx.nd.random_normal(shape=(100, 2), ctx=ctx)\n",
     "fake = netG(noise)\n",
     "\n",
-    "plt.scatter(X[:, 0].asnumpy(),X[:,1].asnumpy())\n",
-    "plt.scatter(fake[:,0].asnumpy(),fake[:,1].asnumpy())\n",
+    "plt.scatter(X[:,0].asnumpy(), X[:,1].asnumpy())\n",
+    "plt.scatter(fake[:,0].asnumpy(), fake[:,1].asnumpy())\n",
     "plt.show()"
    ]
   },

--- a/chapter14_generative-adversarial-networks/gan-intro.ipynb
+++ b/chapter14_generative-adversarial-networks/gan-intro.ipynb
@@ -150,8 +150,8 @@
      "text": [
       "The covariance matrix is\n",
       "\n",
-      "[[ 5.          0.89999998]\n",
-      " [ 0.89999998  0.25999999]]\n",
+      "[[ 1.00999999  1.95000005]\n",
+      " [ 1.95000005  4.25      ]]\n",
       "<NDArray 2x2 @cpu(0)>\n"
      ]
     }
@@ -160,7 +160,7 @@
     "plt.scatter(X[:, 0].asnumpy(),X[:,1].asnumpy())\n",
     "plt.show()\n",
     "print(\"The covariance matrix is\")\n",
-    "print(nd.dot(A, A.T))"
+    "print(nd.dot(A.T, A))"
    ]
   },
   {


### PR DESCRIPTION
Expression for calculating covariance was correctly documented as $A^\\top A$, but the code and output were incorrect.