### PR TITLE
Fix a grammatical error.  Default to CPU as the processor.  Etc.

### DIFF
--- a/chapter04_convolutional-neural-networks/cnn-gluon.ipynb
+++ b/chapter04_convolutional-neural-networks/cnn-gluon.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Convolutional Neural Networks in ``gluon``\n",
     "\n",
-    "Now let's see how succinctly we can express a convolutional neural network using ``gluon``. You might be relieved to find out that this too requires hardly any more code than a logistic regression. "
+    "Now let's see how succinctly we can express a convolutional neural network using ``gluon``. You might be relieved to find out that this too requires hardly any more code than logistic regression. "
    ]
   },
   {
@@ -39,7 +39,8 @@
    },
    "outputs": [],
    "source": [
-    "ctx = mx.gpu()"
+    "# ctx = mx.gpu()\n",
+    "ctx = mx.cpu()"
    ]
   },
   {
@@ -79,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -107,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -125,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -143,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -161,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
@@ -187,11 +188,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0. Loss: 0.0852122314349, Train_acc 0.980466666667, Test_acc 0.981\n"
+     ]
+    }
+   ],
    "source": [
     "epochs = 1\n",
     "smoothing_constant = .01\n",
@@ -259,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix a grammatical error.  Default to CPU as the processor.  Execute all code