### PR TITLE
fix typos in text

### DIFF
--- a/chapter18_variational-methods-and-uncertainty/bayes-by-backprop-gluon.ipynb
+++ b/chapter18_variational-methods-and-uncertainty/bayes-by-backprop-gluon.ipynb
@@ -135,7 +135,7 @@
    "source": [
     "### Neural net modeling\n",
     "\n",
-    "As our model we are using a straightforward MLP and we are wiring up our network just as we are used to in ``gluon``. Note that we are not using any special layers during the definition of our network, as we believe that Bayes by Backprop should be thought of as a training method, rather than a speical architecture."
+    "As our model we are using a straightforward MLP and we are wiring up our network just as we are used to in ``gluon``. Note that we are not using any special layers during the definition of our network, as we believe that Bayes by Backprop should be thought of as a training method, rather than a special architecture."
    ]
   },
   {
@@ -234,7 +234,7 @@
    "source": [
     "## Parameter initialization\n",
     "\n",
-    "First, we need to initialize all the network's parameters, which are only point estimates of the weights at this point. We will soon see, how we can still train the netork in a Bayesian fashion, without interfering with the netowk's architecture."
+    "First, we need to initialize all the network's parameters, which are only point estimates of the weights at this point. We will soon see, how we can still train the network in a Bayesian fashion, without interfering with the network's architecture."
    ]
   },
   {


### PR DESCRIPTION
Fixes two minor typos in Chapter 18:

1. 2 mispellings of 'network'
2. a mispelling of 'special'