### PR TITLE
Spelling Correction of 310 line

### DIFF
--- a/chapter02_supervised-learning/regularization-scratch.ipynb
+++ b/chapter02_supervised-learning/regularization-scratch.ipynb
@@ -307,7 +307,7 @@
     "Another approach is to limit the values that our weights might take. One common approach is to force the weights to take small values. \n",
     "[give more intuition with example of polynomial curve fitting]\n",
     "We can accomplish this by changing our optimization objective to penalize the value of our weights. \n",
-    "The most popular regularizer is the $\\ell^2_2$ norm. For linear models, $\\ell^2_2$ regularization has the additional benefit that it makes the solution unique, even when our model is overparametrized.\n",
+    "The most popular regularizer is the $\\ell^2_2$ norm. For linear models, $\\ell^2_2$ regularization has the additional benefit that it makes the solution unique, even when our model is overparameterized.\n",
     "\n",
     "$$\\sum_{i}(\\hat{y}-y)^2 + \\lambda \\| \\textbf{w} \\|^2_2$$\n",
     "\n",


### PR DESCRIPTION
The word "overparametrized" of 310 line should be "overparameterized".