### PR TITLE
Chapter 8: Fine-tuning: Use GPUs if available

### DIFF
--- a/chapter08_computer-vision/fine-tuning.ipynb
+++ b/chapter08_computer-vision/fine-tuning.ipynb
@@ -113,7 +113,6 @@
     "# Demo mode uses the validation dataset for training, which is smaller and faster to train.\n",
     "demo = True\n",
     "log_interval = 100\n",
-    "gpus = 0\n",
     "\n",
     "# Options are imperative or hybrid. Use hybrid for better performance.\n",
     "mode = 'hybrid'\n",
@@ -151,8 +150,9 @@
     "from mxnet.test_utils import download\n",
     "mx.random.seed(127)\n",
     "\n",
-    "# setup the contexts; change the # of gpus in the settings section above\n",
-    "contexts = [mx.gpu(i) for i in range(gpus)] if gpus > 0 else [mx.cpu()]"
+    "# setup the contexts; will use gpus if avaliable, otherwise cpu\n",
+    "gpus = mx.test_utils.list_gpus()\n",
+    "contexts = [mx.gpu(i) for i in gpus] if len(gpus) > 0 else [mx.cpu()]"
    ]
   },
   {
@@ -292,7 +292,7 @@
     "from mxnet.gluon.model_zoo import vision as models\n",
     "\n",
     "# get pretrained squeezenet\n",
-    "net = models.squeezenet1_1(pretrained=True, prefix='deep_dog_')\n",
+    "net = models.squeezenet1_1(pretrained=True, prefix='deep_dog_', ctx=contexts)\n",
     "# hot dog happens to be a class in imagenet.\n",
     "# we can reuse the weight for that class for better performance\n",
     "# here's the index for that class for later use\n",
@@ -315,7 +315,7 @@
    "outputs": [],
    "source": [
     "deep_dog_net = models.squeezenet1_1(prefix='deep_dog_', classes=2)\n",
-    "deep_dog_net.collect_params().initialize()\n",
+    "deep_dog_net.collect_params().initialize(ctx=contexts)\n",
     "deep_dog_net.features = net.features\n",
     "print(deep_dog_net)"
    ]


### PR DESCRIPTION
Instead of requiring a manual code change from `gpus=0`, added auto-detection for GPU and use if available with `mx.test_utils.list_gpus` function.