### PR TITLE
Fix example to work with Python 2

### DIFF
--- a/chapter13_unsupervised-learning/vae-gluon.ipynb
+++ b/chapter13_unsupervised-learning/vae-gluon.ipynb
@@ -260,7 +260,7 @@
     "        self.output = None\n",
     "        self.mu = None\n",
     "        # note to self: requring batch_size in model definition is sad, not sure how to deal with this otherwise though\n",
-    "        super().__init__(**kwargs)\n",
+    "        super(VAE, self).__init__(**kwargs)\n",
     "        # self.use_aux_logits = use_aux_logits\n",
     "        with self.name_scope():\n",
     "            self.encoder = nn.HybridSequential(prefix='encoder')\n",


### PR DESCRIPTION
Adding arguments needed to call `super()` in Python 2.