### PR TITLE
Update chapter 7 save API

### DIFF
--- a/chapter07_distributed-learning/hybridize.ipynb
+++ b/chapter07_distributed-learning/hybridize.ipynb
@@ -162,7 +162,7 @@
      "output_type": "stream",
      "text": [
       "=== net(x) ===\n",
-      "[[ 0.16526183 -0.14005636]]\n",
+      "[[ 0.08827585  0.0050519 ]]\n",
       "<NDArray 1x2 @cpu(0)>\n"
      ]
     }
@@ -208,7 +208,7 @@
      "output_type": "stream",
      "text": [
       "=== net(x) ===\n",
-      "[[ 0.16526183 -0.14005636]]\n",
+      "[[ 0.08827585  0.0050519 ]]\n",
       "<NDArray 1x2 @cpu(0)>\n"
      ]
     }
@@ -238,8 +238,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Before hybridizing: 0.4646 sec\n",
-      "After hybridizing: 0.2424 sec\n"
+      "Before hybridizing: 0.4344 sec\n",
+      "After hybridizing: 0.2230 sec\n"
      ]
     }
    ],
@@ -298,10 +298,11 @@
       "    {\n",
       "      \"op\": \"null\", \n",
       "      \"name\": \"hybridsequential1_dense0_weight\", \n",
-      "      \"attr\": {\n",
+      "      \"attrs\": {\n",
       "        \"__dtype__\": \"0\", \n",
       "        \"__lr_mult__\": \"1.0\", \n",
       "        \"__shape__\": \"(256, 0)\", \n",
+      "        \"__storage_type__\": \"0\", \n",
       "        \"__wd_mult__\": \"1.0\"\n",
       "      }, \n",
       "      \"inputs\": []\n",
@@ -309,11 +310,12 @@
       "    {\n",
       "      \"op\": \"null\", \n",
       "      \"name\": \"hybridsequential1_dense0_bias\", \n",
-      "      \"attr\": {\n",
+      "      \"attrs\": {\n",
       "        \"__dtype__\": \"0\", \n",
       "        \"__init__\": \"zeros\", \n",
       "        \"__lr_mult__\": \"1.0\", \n",
       "        \"__shape__\": \"(256,)\", \n",
+      "        \"__storage_type__\": \"0\", \n",
       "        \"__wd_mult__\": \"1.0\"\n",
       "      }, \n",
       "      \"inputs\": []\n",
@@ -321,22 +323,27 @@
       "    {\n",
       "      \"op\": \"FullyConnected\", \n",
       "      \"name\": \"hybridsequential1_dense0_fwd\", \n",
-      "      \"attr\": {\"num_hidden\": \"256\"}, \n",
+      "      \"attrs\": {\n",
+      "        \"flatten\": \"True\", \n",
+      "        \"no_bias\": \"False\", \n",
+      "        \"num_hidden\": \"256\"\n",
+      "      }, \n",
       "      \"inputs\": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]\n",
       "    }, \n",
       "    {\n",
       "      \"op\": \"Activation\", \n",
       "      \"name\": \"hybridsequential1_dense0_relu_fwd\", \n",
-      "      \"attr\": {\"act_type\": \"relu\"}, \n",
+      "      \"attrs\": {\"act_type\": \"relu\"}, \n",
       "      \"inputs\": [[3, 0, 0]]\n",
       "    }, \n",
       "    {\n",
       "      \"op\": \"null\", \n",
       "      \"name\": \"hybridsequential1_dense1_weight\", \n",
-      "      \"attr\": {\n",
+      "      \"attrs\": {\n",
       "        \"__dtype__\": \"0\", \n",
       "        \"__lr_mult__\": \"1.0\", \n",
       "        \"__shape__\": \"(128, 0)\", \n",
+      "        \"__storage_type__\": \"0\", \n",
       "        \"__wd_mult__\": \"1.0\"\n",
       "      }, \n",
       "      \"inputs\": []\n",
@@ -344,11 +351,12 @@
       "    {\n",
       "      \"op\": \"null\", \n",
       "      \"name\": \"hybridsequential1_dense1_bias\", \n",
-      "      \"attr\": {\n",
+      "      \"attrs\": {\n",
       "        \"__dtype__\": \"0\", \n",
       "        \"__init__\": \"zeros\", \n",
       "        \"__lr_mult__\": \"1.0\", \n",
       "        \"__shape__\": \"(128,)\", \n",
+      "        \"__storage_type__\": \"0\", \n",
       "        \"__wd_mult__\": \"1.0\"\n",
       "      }, \n",
       "      \"inputs\": []\n",
@@ -356,22 +364,27 @@
       "    {\n",
       "      \"op\": \"FullyConnected\", \n",
       "      \"name\": \"hybridsequential1_dense1_fwd\", \n",
-      "      \"attr\": {\"num_hidden\": \"128\"}, \n",
+      "      \"attrs\": {\n",
+      "        \"flatten\": \"True\", \n",
+      "        \"no_bias\": \"False\", \n",
+      "        \"num_hidden\": \"128\"\n",
+      "      }, \n",
       "      \"inputs\": [[4, 0, 0], [5, 0, 0], [6, 0, 0]]\n",
       "    }, \n",
       "    {\n",
       "      \"op\": \"Activation\", \n",
       "      \"name\": \"hybridsequential1_dense1_relu_fwd\", \n",
-      "      \"attr\": {\"act_type\": \"relu\"}, \n",
+      "      \"attrs\": {\"act_type\": \"relu\"}, \n",
       "      \"inputs\": [[7, 0, 0]]\n",
       "    }, \n",
       "    {\n",
       "      \"op\": \"null\", \n",
       "      \"name\": \"hybridsequential1_dense2_weight\", \n",
-      "      \"attr\": {\n",
+      "      \"attrs\": {\n",
       "        \"__dtype__\": \"0\", \n",
       "        \"__lr_mult__\": \"1.0\", \n",
       "        \"__shape__\": \"(2, 0)\", \n",
+      "        \"__storage_type__\": \"0\", \n",
       "        \"__wd_mult__\": \"1.0\"\n",
       "      }, \n",
       "      \"inputs\": []\n",
@@ -379,11 +392,12 @@
       "    {\n",
       "      \"op\": \"null\", \n",
       "      \"name\": \"hybridsequential1_dense2_bias\", \n",
-      "      \"attr\": {\n",
+      "      \"attrs\": {\n",
       "        \"__dtype__\": \"0\", \n",
       "        \"__init__\": \"zeros\", \n",
       "        \"__lr_mult__\": \"1.0\", \n",
       "        \"__shape__\": \"(2,)\", \n",
+      "        \"__storage_type__\": \"0\", \n",
       "        \"__wd_mult__\": \"1.0\"\n",
       "      }, \n",
       "      \"inputs\": []\n",
@@ -391,7 +405,11 @@
       "    {\n",
       "      \"op\": \"FullyConnected\", \n",
       "      \"name\": \"hybridsequential1_dense2_fwd\", \n",
-      "      \"attr\": {\"num_hidden\": \"2\"}, \n",
+      "      \"attrs\": {\n",
+      "        \"flatten\": \"True\", \n",
+      "        \"no_bias\": \"False\", \n",
+      "        \"num_hidden\": \"2\"\n",
+      "      }, \n",
       "      \"inputs\": [[8, 0, 0], [9, 0, 0], [10, 0, 0]]\n",
       "    }\n",
       "  ], \n",
@@ -412,7 +430,7 @@
       "    12\n",
       "  ], \n",
       "  \"heads\": [[11, 0, 0]], \n",
-      "  \"attrs\": {\"mxnet_version\": [\"int\", 1001]}\n",
+      "  \"attrs\": {\"mxnet_version\": [\"int\", 10300]}\n",
       "}\n"
      ]
     }
@@ -436,7 +454,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can save both the program and parameters onto disk, so that it can be loaded later not only in Python, but in all other supported languages, such as C++, R, and Scala, as well."
+    "Now we can save both the program and parameters onto disk, so that it can be loaded later not only in Python, but in all other supported languages, such as C++, R, and Scala, as well.\n",
+    "For that we use the `.export(prefix, epoch)` function, it will save the json symbolic representation in the format `prefix-symbol.json` and the corresponding parameters as `prefix-{epoch}.params`."
    ]
   },
   {
@@ -447,8 +466,23 @@
    },
    "outputs": [],
    "source": [
-    "y.save('model.json')\n",
-    "net.save_params('model.params')"
+    "net.export('my_model', epoch=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will create two files:\n",
+    "- `my_model-symbol.json`\n",
+    "- `my_model-0000.params`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Learn more about how to load back the models in MXNet various APIs in the official [MXNet tutorial](https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html)"
    ]
   },
   {
@@ -616,7 +650,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.4"
   },
   "name": ""
  },


### PR DESCRIPTION
The previous way of exporting an hybridized model as advertised in Chapter7 does not work anymore in 1.2.0 impacting users who relied on this technique to save their models @piiswrong is working on a fix to keep supporting the old behavior. 

In the meanwhile there is a new cleaner API for exporting a hybridized model using `.export()`, which replace the old advertised way and I have updated the notebook accordingly.
In the works is also `SymbolBlock.imports()` that will let you import directly the exported model back to Gluon, ETA end of this week. 

Please refer to: https://github.com/apache/incubator-mxnet/pull/11127

@piiswrong @zackchase @srochel @szha 

New wording:
![screen shot 2018-06-07 at 1 01 32 pm](https://user-images.githubusercontent.com/3716307/41123281-f8a0c202-6a52-11e8-972f-c77a1447adaf.png)
