### PR TITLE
Removing unused seaborn package

### DIFF
--- a/chapter12_time-series/issm-scratch.ipynb
+++ b/chapter12_time-series/issm-scratch.ipynb
@@ -189,7 +189,6 @@
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "plt.rcParams[\"figure.figsize\"] = (12, 5)\n",
-    "import seaborn as sns"
    ]
   },
   {


### PR DESCRIPTION
Seaborn package is not used in this notebook, but it is not installed by default on CI machine. Removing it from source.