### PR TITLE
Update Jenkinsfile for CI server conda upgrade

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -6,7 +6,7 @@ set -e
 
 # prepare the env
 conda env update -f build/build.yml
-source activate build_gluon_tutorials
+conda activate build_gluon_tutorials
 
 make html
 


### PR DESCRIPTION
Starting with conda v4.4, `source activate` is discouraged. The CI server now runs conda 4.5 so the Jenkinsfile needs to be adapted.