### PR TITLE
Fixing invalid JSON in two notebooks.

### DIFF
--- a/chapter02_supervised-learning/regularization-gluon.ipynb
+++ b/chapter02_supervised-learning/regularization-gluon.ipynb
@@ -185,8 +185,8 @@
     "    fg2.plot(xs, acc_tr)\n",
     "    fg2.plot(xs, acc_ts)\n",
     "    fg2.grid(True,which=\"both\")\n",
-    "    fg2.legend(['training accuracy', 'testing accuracy'],fontsize=14)"
-    "    plt.show()
+    "    fg2.legend(['training accuracy', 'testing accuracy'],fontsize=14)\n",
+    "    plt.show()"
    ]
   },
   {

--- a/chapter12_time-series/issm-scratch.ipynb
+++ b/chapter12_time-series/issm-scratch.ipynb
@@ -188,7 +188,7 @@
     "import numpy as np\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.rcParams[\"figure.figsize\"] = (12, 5)\n",
+    "plt.rcParams[\"figure.figsize\"] = (12, 5)"
    ]
   },
   {


### PR DESCRIPTION
Fixing some notebooks that contained invalid JSON. These notebooks are
causing the test pipline at ci.mxnet.io to fail at present
(http://ci.mxnet.io/job/mxnet-the-straight-dope/88/console) and will
cause the Nightly test on Binaries at
http://jenkins.mxnet-ci.amazon-ml.com/job/NightlyTests_onBinaries/ to
fail if we enable them.