### PR TITLE
Minor word change to avoid triggering warnings.

### DIFF
--- a/chapter01_crashcourse/autograd.ipynb
+++ b/chapter01_crashcourse/autograd.ipynb
@@ -139,7 +139,7 @@
    "source": [
     "## Head gradients and the chain rule\n",
     "\n",
-    "*Warning: This part is tricky, but not necessary to understanding subsequent sections.*\n",
+    "*Caution: This part is tricky, but not necessary to understanding subsequent sections.*\n",
     "\n",
     "Sometimes when we call the backward method on an NDArray, e.g. ``y.backward()``, where ``y`` is a function of ``x`` we are just interested in the derivative of ``y`` with respect to ``x``. Mathematicians write this as $\\frac{dy(x)}{dx}$. At other times, we may be interested in the gradient of ``z`` with respect to ``x``, where ``z`` is a function of ``y``, which in turn, is a function of ``x``. That is, we are interested in $\\frac{d}{dx} z(y(x))$. Recall that by the chain rule $\\frac{d}{dx} z(y(x)) = \\frac{dz(y)}{dy} \\frac{dy(x)}{dx}$. So, when ``y`` is part of a larger function ``z``, and we want ``x.grad`` to store $\\frac{dz}{dx}$, we can pass in the *head gradient* $\\frac{dz}{dy}$ as an input to ``backward()``. The default argument is ``nd.ones_like(y)``. See [Wikipedia](https://en.wikipedia.org/wiki/Chain_rule) for more details."
    ]


### PR DESCRIPTION
MXNet integration tests of the Straight Dope (contained here:
http://jenkins.mxnet-ci.amazon-ml.com/job/NightlyTests_onBinaries/)
execute the notebook and line-scan for warnings and errors in the
output.

Kindly requesting we change 'Warning:' to 'Caution:' to avoid triggering
the log scan regular expression that normally picks up otherwise, we'll
require parsing the JSON in a more heavyweight manner.