### PR TITLE
Fix typo in linear-regression-scratch.ipynb

### DIFF
--- a/chapter02_supervised-learning/linear-regression-scratch.ipynb
+++ b/chapter02_supervised-learning/linear-regression-scratch.ipynb
@@ -372,7 +372,7 @@
     }
    ],
    "source": [
-    "counter = 0\n",
+    "i = 0\n",
     "for i, (data, label) in enumerate(train_data):\n",
     "    pass\n",
     "print(i+1)"


### PR DESCRIPTION
fix variable naming. counter should be renamed as i.