### PR TITLE
Chapter 5's rnn-gluon notebook to use GPU.

### DIFF
--- a/chapter05_recurrent-neural-networks/rnns-gluon.ipynb
+++ b/chapter05_recurrent-neural-networks/rnns-gluon.ipynb
@@ -236,7 +236,7 @@
    },
    "outputs": [],
    "source": [
-    "context = mx.cpu(0)\n",
+    "context = mx.gpu() # this notebook takes too long on cpu\n",
     "corpus = Corpus(args_data)\n",
     "\n",
     "def batchify(data, batch_size):\n",


### PR DESCRIPTION
The rnn gluon notebook takes much too long on the CPU. It takes ~ 5 minutes on a p3.8xl using one of the GPUs.