### PR TITLE
Create new conda environment to get latest packages.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -5,8 +5,8 @@ set -x
 set -e
 
 # prepare the env
-conda env update -f build/build.yml
-conda activate build_gluon_tutorials
+conda env update -f build/build.yml -n build_sd_tutorials
+conda activate build_sd_tutorials
 
 make html
 


### PR DESCRIPTION
The current conda environment is stuck on old versions and those old
versions are failing the build. Recreating Conda environment to allow
for latest versions to be chosen.